### PR TITLE
Six drivebase Falcons

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -29,6 +29,7 @@ void Robot::RobotInit() {
   frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
 // right side might need to be inverted depending on construction
   m_leftDrive.SetInverted(true);
+  
   //  double ballsInShooter = 0; //add when break bar functionality is added
   shootMan = true;
   wrongBall = false;

--- a/src/main/include/Robot.h
+++ b/src/main/include/Robot.h
@@ -111,14 +111,16 @@ class Robot : public frc::TimedRobot {
   frc::XboxController m_stick_climb{1};
 
   WPI_TalonFX m_frontRightMotor = {1};
+  WPI_TalonFX m_midRightMotor = {15};
   WPI_TalonFX m_backRightMotor = {2};
   WPI_TalonFX m_frontLeftMotor = {3};
+  WPI_TalonFX m_midLeftMotor = {16};
   WPI_TalonFX m_backLeftMotor = {4};
 
   // Left side of the robot is inverted
   // Tonk drive
-  frc::MotorControllerGroup m_leftDrive{m_frontLeftMotor, m_backLeftMotor};
-  frc::MotorControllerGroup m_rightDrive{m_frontRightMotor, m_backRightMotor};
+  frc::MotorControllerGroup m_leftDrive{m_frontLeftMotor, m_midLeftMotor, m_backLeftMotor};
+  frc::MotorControllerGroup m_rightDrive{m_frontRightMotor, m_midRightMotor, m_backRightMotor};
 
   frc::DifferentialDrive m_drive{m_leftDrive, m_rightDrive};
 


### PR DESCRIPTION
+ Each side of the drivebase has three falcons as opposed to two
- [NOTE]: Left side of drivetrain inverted. If something doesn't work, invert the right

Why didn't I do this earlier?

-- Commit made by Jeff Bezos Stonerbot
(AKA cynosure or Cynosure-NUL) <cynosure@disroot.org>
My PGP key can be found at https://cynosure.neocities.org/about
Fly safe

 On branch motorGoBrrr
 Changes to be committed:
	modified:   src/main/cpp/Robot.cpp
	modified:   src/main/include/Robot.h