### PR TITLE
Added RPM limiting for intake

### DIFF
--- a/src/main/cpp/Take.cpp
+++ b/src/main/cpp/Take.cpp
@@ -177,7 +177,7 @@ void Take::UptakeStop()
 
 int Take::DeployIntake()
 {
-  if ((fabs(m_rotateIntakeEncoder.GetVelocity()) < 100) && (stowDelayCount > 10)) {
+  if ((fabs(m_rotateIntakeEncoder.GetVelocity()) < 100) && (stowDelayCount > 40)) {
     m_rotateIntakeMotor.Set(0.0);
     return Deployed;
   }
@@ -191,7 +191,7 @@ int Take::DeployIntake()
 
 int Take::ReturnIntake()
 {
-  if ((fabs(m_rotateIntakeEncoder.GetVelocity()) < 100) && (stowDelayCount > 10)) {
+  if ((fabs(m_rotateIntakeEncoder.GetVelocity()) < 100) && (stowDelayCount > 40)) {
     m_rotateIntakeMotor.Set(0.0);
     return Stowed;
   }

--- a/src/main/cpp/Take.cpp
+++ b/src/main/cpp/Take.cpp
@@ -73,6 +73,15 @@ void Take::Run(bool toggle, bool shooting, bool autonomous, frc::DriverStation::
     m_state = Off;
     m_ejectTimer = 0;
   }
+  if (toggle) {stowDelayCount = 0;}
+  else {stowDelayCount = stowDelayCount++;}
+
+if (ReturnIntake() == Stowing) {
+  ReturnIntake();
+}
+if (DeployIntake() == Deploying) {
+  DeployIntake();
+}
 
   // Intake ON or OFF (manual toggle or auto-stop because we're full)
   if (m_state != currentState)
@@ -94,6 +103,7 @@ void Take::Run(bool toggle, bool shooting, bool autonomous, frc::DriverStation::
         ReturnIntake();
     }
   }
+
 }
 
 void Take::ReadSensors(bool toggle) {
@@ -165,14 +175,31 @@ void Take::UptakeStop()
   m_uptakeMotor.Set(0);
 }
 
-void Take::DeployIntake()
+int Take::DeployIntake()
 {
-  m_rotateIntakePIDController.SetReference(50.5, rev::CANSparkMax::ControlType::kSmartMotion);
+  if (m_rotateIntakeEncoder.GetVelocity() < abs(100) && stowDelayCount < 10) {
+  m_rotateIntakeMotor.Set(0.0);
+  return Deployed;
+  }
+  else {
+    m_rotateIntakeMotor.Set(0.5);
+    return Deploying;
+
+  }
+  //m_rotateIntakePIDController.SetReference(50.5, rev::CANSparkMax::ControlType::kSmartMotion);
 }
 
-void Take::ReturnIntake()
+int Take::ReturnIntake()
 {
-  m_rotateIntakePIDController.SetReference(0.0, rev::CANSparkMax::ControlType::kSmartMotion);
+    if (m_rotateIntakeEncoder.GetVelocity() < abs(100) && stowDelayCount < 10) {
+  m_rotateIntakeMotor.Set(0.0);
+  return Stowed;
+  }
+  else {
+    m_rotateIntakeMotor.Set(-0.5);
+    return Stowing;
+  }
+  //m_rotatentakePIDController.SetReference(0.0, rev::CANSparkMax::ControlType::kSmartMotion);
 }
 
 void Take::AutoRunIntake(double speed){

--- a/src/main/cpp/Take.cpp
+++ b/src/main/cpp/Take.cpp
@@ -177,9 +177,9 @@ void Take::UptakeStop()
 
 int Take::DeployIntake()
 {
-  if (m_rotateIntakeEncoder.GetVelocity() < abs(100) && stowDelayCount < 10) {
-  m_rotateIntakeMotor.Set(0.0);
-  return Deployed;
+  if ((fabs(m_rotateIntakeEncoder.GetVelocity()) < 100) && (stowDelayCount > 10)) {
+    m_rotateIntakeMotor.Set(0.0);
+    return Deployed;
   }
   else {
     m_rotateIntakeMotor.Set(0.5);
@@ -191,9 +191,9 @@ int Take::DeployIntake()
 
 int Take::ReturnIntake()
 {
-    if (m_rotateIntakeEncoder.GetVelocity() < abs(100) && stowDelayCount < 10) {
-  m_rotateIntakeMotor.Set(0.0);
-  return Stowed;
+  if ((fabs(m_rotateIntakeEncoder.GetVelocity()) < 100) && (stowDelayCount > 10)) {
+    m_rotateIntakeMotor.Set(0.0);
+    return Stowed;
   }
   else {
     m_rotateIntakeMotor.Set(-0.5);

--- a/src/main/cpp/Take.cpp
+++ b/src/main/cpp/Take.cpp
@@ -76,12 +76,37 @@ void Take::Run(bool toggle, bool shooting, bool autonomous, frc::DriverStation::
   if (toggle) {stowDelayCount = 0;}
   else {stowDelayCount = stowDelayCount++;}
 
+if (toggle) {
+  if (m_rotate == Stowed) {
+    DeployIntake();
+    m_rotate = Deploying;
+  }
+  if (m_rotate == Deployed) {
+    ReturnIntake();
+    m_rotate = Stowing;
+  }
+
+}
+
+if (m_rotate == Deploying) {
+  DeployIntake();
+
+  }
+if (m_rotate == Stowing) {
+  ReturnIntake();
+  }
+
+
+
+
+/*
 if (ReturnIntake() == Stowing) {
   ReturnIntake();
 }
 if (DeployIntake() == Deploying) {
   DeployIntake();
 }
+*/
 
   // Intake ON or OFF (manual toggle or auto-stop because we're full)
   if (m_state != currentState)
@@ -175,14 +200,18 @@ void Take::UptakeStop()
   m_uptakeMotor.Set(0);
 }
 
+/* -------- */
+
 int Take::DeployIntake()
 {
   if ((fabs(m_rotateIntakeEncoder.GetVelocity()) < 100) && (stowDelayCount > 40)) {
     m_rotateIntakeMotor.Set(0.0);
+    m_rotate = Deployed;
     return Deployed;
   }
   else {
     m_rotateIntakeMotor.Set(0.5);
+    m_rotate = Deploying;
     return Deploying;
 
   }
@@ -193,10 +222,12 @@ int Take::ReturnIntake()
 {
   if ((fabs(m_rotateIntakeEncoder.GetVelocity()) < 100) && (stowDelayCount > 40)) {
     m_rotateIntakeMotor.Set(0.0);
+    m_rotate = Stowed;
     return Stowed;
   }
   else {
     m_rotateIntakeMotor.Set(-0.5);
+    m_rotate = Stowing;
     return Stowing;
   }
   //m_rotatentakePIDController.SetReference(0.0, rev::CANSparkMax::ControlType::kSmartMotion);

--- a/src/main/include/Take.h
+++ b/src/main/include/Take.h
@@ -39,8 +39,8 @@ public:
   void UptakeStart(double speed);
   void UptakeStop();
 
-  void DeployIntake();
-  void ReturnIntake();
+  int DeployIntake();
+  int ReturnIntake();
 
   void TestDashInit();
   void TestDashRead();
@@ -64,6 +64,13 @@ public:
     Ejecting,
   };
 
+    enum RotateState {
+    Stowed,
+    Deployed,
+    Deploying,
+    Stowing
+  };
+
 private:
 
   // Determine the ball color from Color Sensor value
@@ -83,6 +90,8 @@ private:
 
   bool intakeRunning = false;
 
+  int stowDelayCount = 0;
+  int deployDelayCount = 0;
   frc::DriverStation::Alliance m_alliance;
 
   /* Shuffleboard */

--- a/src/main/include/Take.h
+++ b/src/main/include/Take.h
@@ -92,6 +92,8 @@ private:
 
   int stowDelayCount = 0;
   int deployDelayCount = 0;
+  RotateState m_rotate = Stowed;
+
   frc::DriverStation::Alliance m_alliance;
 
   /* Shuffleboard */


### PR DESCRIPTION
Added RPM limits to intake because PIDs had issues re zeroing.
Now current changes based on the speed of the motor.
Ask me for info about logical flow.

-- Commit made by Jeff Bezos Stonerbot
(AKA cynosure or Cynosure-NUL) <cynosure@disroot.org>
My PGP key can be found at https://cynosure.neocities.org/about
Fly safe

 On branch intake-rotation-fix
 Changes to be committed:
	modified:   src/main/cpp/Take.cpp
	modified:   src/main/include/Take.h